### PR TITLE
Fix card title display in confirmation message

### DIFF
--- a/src/trello.js
+++ b/src/trello.js
@@ -68,7 +68,7 @@ const sendConfirmation = (card) => {
   axios.post('https://slack.com/api/chat.postMessage', qs.stringify({
     token: process.env.SLACK_ACCESS_TOKEN,
     channel: slackChannel,
-    text: `new ${card.category} from ${card.userRealName}: card.title`,
+    text: `new ${card.category} from ${card.userRealName}: ${card.title}`,
     attachments: JSON.stringify([
       {
         title: card.title,


### PR DESCRIPTION
was just displaying `card.title` oops.